### PR TITLE
Add --random_selfplay option to play 1 game with random agents, which

### DIFF
--- a/backgammon/game.py
+++ b/backgammon/game.py
@@ -12,6 +12,7 @@ class Game:
     OFF = 'off'
     ON = 'on'
     TOKENS = ['x', 'o']
+    SLEEP = 1
 
     def __init__(self, layout=LAYOUT, grid=None, off_pieces=None, bar_pieces=None, num_pieces=None, players=None):
         """
@@ -80,10 +81,13 @@ class Game:
     def take_turn(self, player, roll, draw=False):
         if draw:
             print("Player %s rolled <%d, %d>." % (player.player, roll[0], roll[1]))
-            time.sleep(1)
+            time.sleep(self.SLEEP)
 
         moves = self.get_actions(roll, player.player, nodups=True)
         move = player.get_action(moves, self) if moves else None
+
+        if draw:
+            print("Player %s played %s" % (player.player, str(move)))
 
         if move:
             self.take_action(move, player.player)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_boolean('test', False, 'If true, test against a random strategy.')
 flags.DEFINE_boolean('play', False, 'If true, play against a trained TD-Gammon strategy.')
+flags.DEFINE_boolean('random_selfplay', False, 'Watch 2 random agents play')
 flags.DEFINE_boolean('restore', False, 'If true, restore a checkpoint before training.')
 
 model_path = os.environ.get('MODEL_PATH', 'models/')
@@ -32,5 +33,7 @@ if __name__ == '__main__':
             model.test(episodes=1000)
         elif FLAGS.play:
             model.play()
+        elif FLAGS.random_selfplay:
+            model.random_selfplay()
         else:
             model.train()

--- a/model.py
+++ b/model.py
@@ -192,6 +192,12 @@ class Model(object):
                 winners[0], winners[1], winners_total, \
                 (winners[0] / winners_total) * 100.0))
 
+    def random_selfplay(self):
+        players = [RandomAgent(Game.TOKENS[0]), RandomAgent(Game.TOKENS[1])]
+        game = Game.new()
+        game.SLEEP = 0
+        winner = game.play(players, draw=True)
+
     def train(self):
         tf.train.write_graph(self.sess.graph_def, self.model_path, 'td_gammon.pb', as_text=False)
         summary_writer = tf.train.SummaryWriter('{0}{1}'.format(self.summary_path, int(time.time()), self.sess.graph_def))


### PR DESCRIPTION
shows a bug - the moves made ("Player XXX played MOVE") always
have increasing indices.

Sample output:

python -u main.py --random_selfplay
...

```
Player o rolled <6, 4>.
Player o played** ((16, 20), (0, 6))**                                              <-- note increasing indices
| 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
|  x |    |    |    |  o |    |  o |    |  o |    |    |  x |
|  x |    |    |    |  o |    |  o |    |    |    |    |  x |
|  x |    |    |    |    |    |  o |    |    |    |    |    |
|  x |    |    |    |    |    |  o |    |    |    |    |    |
|  x |    |    |    |    |    |  o |    |    |    |    |    |


|  o |    |    |    |    |    |  x |    |    |    |    |    |
|  o |    |    |    |    |    |  x |    |    |    |    |    |
|  o |    |    |    |  x |    |  x |    |    |    |    |    |
|  o |    |    |    |  x |    |  x |    |    |    |    |    |
|  o |    |    |    |  x |  o |  x |    |    |    |    |  o |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
| 11 | 10 |  9 |  8 |  7 |  6 |  5 |  4 |  3 |  2 |  1 |  0 |
<Player x>  Off Board :     Bar :
<Player o>  Off Board :     Bar :
Player x rolled <5, 1>.
Player x played **((7, 8), (8, 13))**                <-- this player also has increasing indices
...

```
